### PR TITLE
:sound: SummaryにScanErrorの理由を出力する

### DIFF
--- a/01test/tc_test.py
+++ b/01test/tc_test.py
@@ -34,7 +34,7 @@ def common_task(mpl_file, out_file):
         sout = exec_res.pop(0)
         serr = exec_res.pop(0)
         if serr:
-            raise ScanError
+            raise ScanError(serr)
         for line in sout.splitlines():
             formatted = re.sub(r'\s*"\s*(\S*)\s*"\s*(\d+)\s*', r'"\1"\t\2\n', line)
             out.append(formatted)
@@ -52,7 +52,7 @@ def common_task(mpl_file, out_file):
                     fp.write(l+'\n')
             return 1
         else:
-            raise ScanError        
+            raise ScanError(serr)
     except Exception as err:
         with open(out_file, mode='w') as fp:
             print(err, file=fp)

--- a/01test_ex/tc_test.py
+++ b/01test_ex/tc_test.py
@@ -35,7 +35,7 @@ def common_task(mpl_file, out_file):
         serr = exec_res.pop(0)
         if len(serr) > 0:
             print(f'err message [{serr}]', file=sys.stderr)
-            raise ScanError
+            raise ScanError(serr)
         for line in sout.splitlines():
             formatted = re.sub(r'\s', r'', line)
             formatted = re.sub(r'^\t', r'', formatted)
@@ -54,7 +54,7 @@ def common_task(mpl_file, out_file):
                     fp.write(l+'\n')
             return 1
         else:
-            raise ScanError        
+            raise ScanError(serr)
     except Exception as err:
         with open(out_file, mode='w') as fp:
             print(err, file=fp)

--- a/02test/pp_test.py
+++ b/02test/pp_test.py
@@ -33,7 +33,7 @@ def common_task(mpl_file, out_file):
         sout = exec_res.pop(0)
         serr = exec_res.pop(0)
         if serr:
-            raise ParseError
+            raise ParseError(serr)
         for line in sout.splitlines():
             out.append(line)
         with open(out_file, mode='w') as fp:
@@ -49,7 +49,7 @@ def common_task(mpl_file, out_file):
                     fp.write(l+'\n')
             return 1
         else:
-            raise ParseError        
+            raise ParseError(serr)
     except Exception as err:
         with open(out_file, mode='w') as fp:
             print(err, file=fp)

--- a/03test/cr_test.py
+++ b/03test/cr_test.py
@@ -33,7 +33,7 @@ def common_task(mpl_file, out_file):
         sout = exec_res.pop(0)
         serr = exec_res.pop(0)
         if serr:
-            raise SemanticError
+            raise SemanticError(serr)
         for line in sout.splitlines():
             out.append(re.sub(r'\s',r'',line))
         if out != []:
@@ -44,7 +44,7 @@ def common_task(mpl_file, out_file):
                     fp.write(l+'\n')
             return 0
         else:
-            raise SemanticError
+            raise SemanticError(serr)
     except SemanticError:
         if re.search(r'sample0', mpl_file):
             for line in serr.splitlines():
@@ -54,7 +54,7 @@ def common_task(mpl_file, out_file):
                     fp.write(l+'\n')
             return 1
         else:
-            raise SemanticError
+            raise SemanticError(serr)
     except Exception as err:
         with open(out_file, mode='w') as fp:
             print(err, file=fp)


### PR DESCRIPTION
# 概要

ScanErrorの理由として、stderrに出力された内容を表示するようにしました。
No such file or directoryは取れるようになるのは嬉しいですね

```
FAILED tc_test.py::test_run[../input01/sample11.mpl] - tc_test.ScanError: /bin/sh: /workspaces/tc: No such file or directory
```