### PR TITLE
出力が無い時にassertが実行されないのを修正

### DIFF
--- a/01test/01_tc_run_test.py
+++ b/01test/01_tc_run_test.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import glob
 import subprocess
 import pytest
+import itertools
+
 
 TARGET = "tc"
 TARGETPATH = "/workspaces"
@@ -88,8 +90,8 @@ def test_run(mpl_file):
         with open(out_file, encoding='utf-8') as ofp, open(expect_file, encoding='utf-8') as efp:
             out_cont = ofp.read().splitlines()
             est_cont = efp.read().splitlines()
-            for i, out_line in enumerate(out_cont):
-                assert out_line == est_cont[i], "Line does not match."
+            for out_line, est_line in itertools.zip_longest(out_cont, est_cont, fillvalue=""):
+                assert out_line == est_line, "Line does not match."
     else:
         with open(out_file, encoding='utf-8') as ofp:
             assert not ofp.read() == '', "Error message should appear."

--- a/01test_ex/01_tc_run_test.py
+++ b/01test_ex/01_tc_run_test.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import glob
 import subprocess
 import pytest
+import itertools
+
 
 TARGET = "tc"
 TARGETPATH = "/workspaces"
@@ -82,8 +84,8 @@ def test_run(mpl_file):
         with open(out_file, encoding='utf-8') as ofp, open(expect_file, encoding='utf-8') as efp:
             out_cont = ofp.read().splitlines()
             est_cont = efp.read().splitlines()
-            for i, out_line in enumerate(out_cont):
-                assert out_line == est_cont[i], "Line does not match."
+            for out_line, est_line in itertools.zip_longest(out_cont, est_cont):
+                assert out_line == est_line, "Line does not match."
     else:
         with open(out_file, encoding='utf-8') as ofp:
             assert not ofp.read() == '', "Error message should appear."

--- a/02test/01_pp_run_test.py
+++ b/02test/01_pp_run_test.py
@@ -6,6 +6,8 @@ import sys
 import re
 from pathlib import Path
 import pytest
+import itertools
+
 
 TARGET = "pp"
 TARGETPATH = "/workspaces"
@@ -84,8 +86,10 @@ def test_run(mpl_file):
         with open(out_file,encoding='utf-8') as ofp, open(expect_file,encoding='utf-8') as efp:
             out_cont = ofp.read().splitlines()
             est_cont = efp.read().splitlines()
-            for i, out_line in enumerate(out_cont):
-                assert out_line == est_cont[i], "Line does not match."
+            for out_line, est_line in itertools.zip_longest(out_cont, est_cont, fillvalue=""):
+                assert out_line == est_line, "Line does not match."
+
+
     # 異常終了した場合
     else:
         # エラーの行番号が正しいかを確認

--- a/02test/02_pp_mm_test.py
+++ b/02test/02_pp_mm_test.py
@@ -8,6 +8,8 @@ import sys
 import re
 from pathlib import Path
 import pytest
+import itertools
+
 
 TARGET = "pp"
 TARGETPATH = "/workspaces"
@@ -88,8 +90,8 @@ def test_idempotency(mpl_file):
             with open(out2_file,encoding='utf-8') as ofp2, open(out_file,encoding='utf-8') as ofp1:
                 out_cont = ofp2.read().splitlines()
                 est_cont = ofp1.read().splitlines()
-                for i, out_line in enumerate(out_cont):
-                    assert out_line == est_cont[i], "Line does not match."
+            for out_line, est_line in itertools.zip_longest(out_cont, est_cont, fillvalue=""):
+                assert out_line == est_line, "Line does not match."
         else:
             # 実行結果がエラーになるのであれば，それはダメ
             assert False, "Pretty print idempotency is broken."

--- a/03test/01_cr_run_test.py
+++ b/03test/01_cr_run_test.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import glob
 import subprocess
 import pytest
+import itertools
+
 
 TARGET = "cr"
 TARGETPATH = "/workspaces"
@@ -80,8 +82,9 @@ def test_cr_run(mpl_file):
         with open(out_file, encoding='utf-8') as ofp, open(expect_file, encoding='utf-8') as efp:
             out_cont = ofp.read().splitlines()
             est_cont = efp.read().splitlines()
-            for i, out_line in enumerate(out_cont):
-                assert out_line == est_cont[i], "Line does not match."
+            for out_line, est_line in itertools.zip_longest(out_cont, est_cont, fillvalue=""):
+                assert out_line == est_line, "Line does not match."
+
     else:
         expect_file = Path(TEST_EXPECT_DIR).joinpath(Path(mpl_file).stem + ".stderr")
         with open(out_file, encoding='utf-8') as ofp, open(expect_file, encoding='utf-8') as efp:

--- a/04test/01_mpplc_c2c2_run_test.py
+++ b/04test/01_mpplc_c2c2_run_test.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import glob
 import subprocess
 import pytest
+import itertools
+
 
 TARGET = "mpplc"
 TARGETPATH = "/workspaces"
@@ -135,8 +137,8 @@ def test_mpplc_run(mpl_file):
         with open(out_file,encoding='utf-8') as ofp, open(expect_file,encoding='utf-8') as efp:
             out_cont = ofp.read().splitlines()
             est_cont = efp.read().splitlines()
-            for i, out_line in enumerate(out_cont):
-                assert out_line == est_cont[i], "Line does not match."
+            for out_line, est_line in itertools.zip_longest(out_cont, est_cont, fillvalue=""):
+                assert out_line == est_line, "Line does not match."
     else:
         expect_file = Path(TEST_EXPECT_DIR)/Path(Path(mpl_file).name + ".stderr")
         with open(out_file,encoding='utf-8') as ofp, open(expect_file,encoding='utf-8') as efp:


### PR DESCRIPTION
## 概要

正解は何か出力があるが、実際の出力には何もない時にassertが実行されず、テストとしてはPASS扱いになってしまっていたのを修正します。

https://docs.python.org/ja/3/library/itertools.html#itertools.zip_longest

配列の長さが長い方に合わせてfor文を繰り返すようにするために`itertools.zip_longest`を使い、出力が短い方には足りない分は`""` として扱って比較されるよう `fillvalue=""` としてしています。

ファイル全体の文字列が一致しているかを確認する代わりに、1行ずつ比較するようになってから発生していたよう。